### PR TITLE
Trimmed query value before searching.

### DIFF
--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -134,7 +134,7 @@
 
             var suggestions = ko.computed(function () {
                 var data = unwrapObservable(options.data);
-                var queryText = (unwrapObservable(query) || '').toLowerCase();
+                var queryText = (unwrapObservable(query) || '').trim().toLowerCase();
                 if (queryText.length < minLength) {
                     return [];
                 } else {


### PR DESCRIPTION
Leading/trailing whitespace or a string consisting of only whitespace should be ignored by the query searcher.